### PR TITLE
Keep release lockfile synchronized

### DIFF
--- a/.github/workflows/deploy-on-tag.yml
+++ b/.github/workflows/deploy-on-tag.yml
@@ -22,7 +22,7 @@ jobs:
         run: |
           # Get the tag name without the leading 'v_'
           VERSION=${GITHUB_REF#refs/tags/v_}
-          echo "version=$VERSION" >> $GITHUB_ENV
+          echo "VERSION=$VERSION" >> "$GITHUB_ENV"
           CURRENT_VERSION=$(grep "^version =" pyproject.toml | cut -d'"' -f2)
 
           # Check if the version needs to be updated
@@ -35,32 +35,31 @@ jobs:
 
           cat pyproject.toml | grep version
 
-      - name: Commit Version Update
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          # Check if there are changes to commit
-          if git diff --quiet pyproject.toml; then
-            echo "No changes detected in pyproject.toml. Skipping commit and push."
-          else
-            echo "Changes detected in pyproject.toml. Committing and pushing..."
-            git config --local user.name "github-actions"
-            git config --local user.email "github-actions@github.com"
-            git add pyproject.toml
-            git commit -m "Update version to $VERSION based on tag"
-            git push origin HEAD:main
-          fi
-
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: '3.12'
 
       - name: Ensure latest pip
         run: python -m pip install --upgrade pip
 
       - name: Install uv
         run: pip install uv
+
+      - name: Commit Version Update
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          uv lock
+          if git diff --quiet pyproject.toml uv.lock; then
+            echo "No version changes detected. Skipping commit and push."
+          else
+            git config --local user.name "github-actions"
+            git config --local user.email "github-actions@github.com"
+            git add pyproject.toml uv.lock
+            git commit -m "Update version to $VERSION based on tag"
+            git push origin HEAD:main
+          fi
 
       - name: Install dependencies
         run: |

--- a/uv.lock
+++ b/uv.lock
@@ -263,7 +263,7 @@ web = [
 
 [[package]]
 name = "hg-oap"
-version = "0.2.0"
+version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "hg-cpp", extra = ["web"] },


### PR DESCRIPTION
## Summary

- synchronize `uv.lock` with the released `hg_oap 0.3.0` version
- make the tag workflow refresh and commit `uv.lock` with `pyproject.toml`
- expose the tag version to later steps and use the supported Python 3.12 runtime

## Why

The `v_0.3.0` workflow published successfully, but its version-update commit only included `pyproject.toml`. That left `main` failing `uv lock --check` and produced a commit message with a missing version.

## Validation

- `uv lock --check`
- workflow YAML parse
- `203 passed, 2 skipped, 2 xfailed`
