### PR TITLE
Use dataclasses directly as bundle schemas

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 requires-python = ">=3.12"
 dependencies = [
     #"hgraph[web]>=0.5.25",
-    "hg_cpp[web]>=0.4.5",
+    "hg_cpp[web]>=0.4.9",
     "holidays >=0.56",
     "polars>=1.32",
 ]

--- a/src/hg_oap/orders/order.py
+++ b/src/hg_oap/orders/order.py
@@ -4,8 +4,8 @@ from typing import Generic, TypeVar
 from hgraph import TimeSeriesSchema, TS, TSS, TSD, TSB, reference_service
 
 from hg_oap.orders.order_type import OrderType, MultiLegOrderType, SingleLegOrderType
-from hg_oap.pricing.price import Price, PriceBundle
-from hg_oap.units.quantity import Quantity, QuantityBundle
+from hg_oap.pricing.price import Price
+from hg_oap.units.quantity import Quantity
 
 __all__ = (
     'ORDER', 'LEG_ID', 'OriginatorInfo', 'Fill', 'Order', 'SingleLegOrder', 'MultiLegOrder', 'OrderState',
@@ -62,9 +62,9 @@ class SingleLegOrder(Order):
     provide the historical state of all received fills.
     """
     order_type: TS[SingleLegOrderType]
-    remaining_qty: TSB[QuantityBundle]
-    filled_qty: TSB[QuantityBundle]
-    filled_notional: TSB[PriceBundle]
+    remaining_qty: TSB[Quantity]
+    filled_qty: TSB[Quantity]
+    filled_notional: TSB[Price]
     is_filled: TS[bool]
     fills: TS[Fill]
 
@@ -79,9 +79,9 @@ class MultiLegOrder(Order):
     Examples include IfDone, OneCancelOther, etc.
     """
     order_type: TS[MultiLegOrderType]
-    remaining_qty: TSD[LEG_ID, TSB[QuantityBundle]]
-    filled_qty: TSD[LEG_ID, TSB[QuantityBundle]]
-    filled_notional: TSD[LEG_ID, TSB[PriceBundle]]
+    remaining_qty: TSD[LEG_ID, TSB[Quantity]]
+    filled_qty: TSD[LEG_ID, TSB[Quantity]]
+    filled_notional: TSD[LEG_ID, TSB[Price]]
     is_filled: TSD[LEG_ID, TS[bool]]
     fills: TSD[LEG_ID, TS[Fill]]
     is_leg_complete: TSD[LEG_ID, TS[bool]]

--- a/src/hg_oap/position/position.py
+++ b/src/hg_oap/position/position.py
@@ -1,7 +1,7 @@
 from hgraph import TimeSeriesSchema, TS, TSB
 
 from hg_oap.instruments.instrument import Instrument
-from hg_oap.pricing.price import PriceBundle
+from hg_oap.pricing.price import Price
 
 
 class InstrumentQuantity(TimeSeriesSchema):
@@ -12,4 +12,4 @@ class InstrumentQuantity(TimeSeriesSchema):
 
 class Position(InstrumentQuantity):
     """A position represent a holding in a particular instrument along with a notional"""
-    notional: TSB[PriceBundle]
+    notional: TSB[Price]

--- a/src/hg_oap/pricing/price.py
+++ b/src/hg_oap/pricing/price.py
@@ -6,7 +6,7 @@ from hgraph import TimeSeriesSchema, TS, Array, SIZE, TSB
 from hg_oap.assets.currency import Currency
 from hg_oap.units.unit import UNIT
 
-__all__ = ("Price", "PriceBundle", "L1Price", "L2Price", "PriceProfile")
+__all__ = ("Price", "L1Price", "L2Price", "PriceProfile")
 
 
 @dataclass(frozen=True)
@@ -23,9 +23,6 @@ class Price:
             return Price(price=self.price + other.price, currency=self.currency)
         else:
             raise ValueError(f"Cannot add {self} to {other} of {self.currency}")
-
-
-PriceBundle = TimeSeriesSchema.from_scalar_schema(Price)
 
 
 @dataclass

--- a/src/hg_oap/pricing/pricing_services.py
+++ b/src/hg_oap/pricing/pricing_services.py
@@ -4,12 +4,12 @@ from hgraph.adaptors.data_frame import DATA_FRAME_SOURCE, tsd_k_b_from_data_sour
 
 from hg_oap.assets.currency import Currency
 from hg_oap.impl.assets.currency import Currencies
-from hg_oap.pricing.price import PriceBundle
+from hg_oap.pricing.price import Price
 
 __all__ =("price_mid", "price_mid_table_impl")
 
 @subscription_service
-def price_mid(instrument_id: TS[str], path: str = default_path) -> TSB[PriceBundle]:
+def price_mid(instrument_id: TS[str], path: str = default_path) -> TSB[Price]:
     """
     Simple pricing where the price is a simple value and currency, this is true of mid-prices, fixings, and other
     referenced prices that are often used for systematic trading strategies.
@@ -25,7 +25,7 @@ def price_mid_table_impl(
         price_col: str = 'price',
         currency_col: str = 'currency',
         static_currency: str = None
-) -> TSD[str, TSB[PriceBundle]]:
+) -> TSD[str, TSB[Price]]:
     """
     Produces a stream of pricing for the instruments subscribed to from the data frame produced by the DataFrameSource
     provided. To keep this simple, the input ids are ignored, we just produce a complete TSD of all potential
@@ -71,13 +71,13 @@ def price_mid_table_impl(
 
 
 @graph
-def _clean_up_static_currency(price: REF[TS[float]], currency: REF[TS[Currency]]) -> TSB[PriceBundle]:
-    return TSB[PriceBundle].from_ts(price=price, currency=currency)
+def _clean_up_static_currency(price: REF[TS[float]], currency: REF[TS[Currency]]) -> TSB[Price]:
+    return TSB[Price].from_ts(price=price, currency=currency)
 
 
 @graph
-def _clean_up_dynamic_currency(price: TSB[TS_SCHEMA], price_col: str, currency_col: str) -> TSB[PriceBundle]:
-    return TSB[PriceBundle].from_ts(
+def _clean_up_dynamic_currency(price: TSB[TS_SCHEMA], price_col: str, currency_col: str) -> TSB[Price]:
+    return TSB[Price].from_ts(
         price=getattr(price, price_col),
         currency=cast_(Currency, drop_dups(getattr(price, currency_col)))
     )

--- a/src/hg_oap/units/quantity.py
+++ b/src/hg_oap/units/quantity.py
@@ -3,7 +3,6 @@ from numbers import Number
 
 from hg_oap.units.unit import Unit
 from hgraph import (
-    TimeSeriesSchema,
     compute_node,
     div_,
     TS,
@@ -13,7 +12,7 @@ from hgraph import (
     DivideByZero,
 )
 
-__all__ = ("Quantity", "QuantityBundle")
+__all__ = ("Quantity",)
 
 
 EPSILON = 1e-9
@@ -116,9 +115,6 @@ class Quantity:
 
     def as_(self, unit):
         return Quantity(self.unit.convert(self.qty, to=unit), unit)
-
-
-QuantityBundle = TimeSeriesSchema.from_scalar_schema(Quantity)
 
 
 @compute_node(overloads=div_)

--- a/tests/unit/hg_oap/pricing/test_pricing_services.py
+++ b/tests/unit/hg_oap/pricing/test_pricing_services.py
@@ -5,7 +5,7 @@ from hgraph.adaptors.data_frame import *
 from hgraph.test import eval_node
 
 from hg_oap.impl.assets.currency import Currencies
-from hg_oap.pricing.price import PriceBundle
+from hg_oap.pricing.price import Price
 from hg_oap.pricing.pricing_services import price_mid_table_impl, price_mid
 
 
@@ -33,7 +33,7 @@ class PriceCurrDataFrame(DataFrameSource):
 def test_price_mid():
 
     @graph
-    def g() -> TSB[PriceBundle]:
+    def g() -> TSB[Price]:
         register_service(default_path, price_mid_table_impl, data_frame_source=PriceDataFrame, static_currency="USD")
         return price_mid("a")
 
@@ -42,9 +42,8 @@ def test_price_mid():
 
 def test_price_mid_with_currency():
     @graph
-    def g() -> TSB[PriceBundle]:
+    def g() -> TSB[Price]:
         register_service(default_path, price_mid_table_impl, data_frame_source=PriceCurrDataFrame, currency_col="curr")
         return price_mid("a")
 
     assert eval_node(g) == [fd(price=1.0, currency=Currencies.EUR.value), fd(price=3.0)]
-

--- a/tests/unit/hg_oap/utils/test_dataclass_models.py
+++ b/tests/unit/hg_oap/utils/test_dataclass_models.py
@@ -108,3 +108,8 @@ def test_stream_supports_python_owned_dataclass_payloads():
         "origin",
         "size",
     }
+
+
+def test_dataclass_models_define_bundle_schemas_directly():
+    assert set(time_series_fields(TSB[MarketPrice])) == {"price", "currency"}
+    assert set(time_series_fields(TSB[Quantity])) == {"qty", "unit"}

--- a/uv.lock
+++ b/uv.lock
@@ -242,18 +242,18 @@ wheels = [
 
 [[package]]
 name = "hg-cpp"
-version = "0.4.5"
+version = "0.4.9"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "frozendict" },
     { name = "numpy" },
     { name = "pyarrow" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6b/51/29d3a2b8fda16c47a9ce1b737681a5ceb8318b56dbc1ddea7a685fa591c8/hg_cpp-0.4.5.tar.gz", hash = "sha256:2accbf95afaaf0282c6442222eb89ac16f0308985b25da5dc061621383a150c8", size = 2297961, upload-time = "2026-07-25T16:03:53.589Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0e/ab/e47acef9062b62748ae10e84b56051b74126de70cf042d290bb944edec1e/hg_cpp-0.4.9.tar.gz", hash = "sha256:796e2566f8a09da730391a1ead8346e9b56a60867a452ddd2d57a96708c60d09", size = 2381983, upload-time = "2026-07-27T11:41:11.644Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3a/80/93cff98af8514b4478f324ab9e91a6e00ba0df59ea443f9c9b64d8bc4de3/hg_cpp-0.4.5-cp312-abi3-macosx_15_0_arm64.whl", hash = "sha256:1b8c7773d822d09ccb4e14df7ae5bb08929519cf170732faaec91b241222b63e", size = 6908006, upload-time = "2026-07-25T16:03:47.428Z" },
-    { url = "https://files.pythonhosted.org/packages/b9/5e/ddcc6b223439cee77b7e1ae7f7bc848168bcb5d0e4dbd64e614a389d11af/hg_cpp-0.4.5-cp312-abi3-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:edc7eea30828ef0119a6264c0bb4369cb52abc23ef687933f67b0c0e864a17cc", size = 9086439, upload-time = "2026-07-25T16:03:49.434Z" },
-    { url = "https://files.pythonhosted.org/packages/3e/b4/9ad9043b6cbb382fe9708408ffa5fac0acaaf2b59ca5a6b80c71b27adde8/hg_cpp-0.4.5-cp312-abi3-win_amd64.whl", hash = "sha256:69ce7e3147735df4f542ea4d00baa5327706c43356d1b7b47e556b7ac6f9a7c7", size = 16201001, upload-time = "2026-07-25T16:03:51.427Z" },
+    { url = "https://files.pythonhosted.org/packages/80/85/b4cdf34904f619e282c0e52beb7b592525d168322cd4df5a531a037be91b/hg_cpp-0.4.9-cp312-abi3-macosx_15_0_arm64.whl", hash = "sha256:66725acb099e80fa5619c7c418acac328178d976de7196712c018d7950baa4b6", size = 6953873, upload-time = "2026-07-27T11:41:05.294Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/4e/3abd67f0bb37240a6b4dfcc0d967c7b1e512658dad1f3c135101553ffd9b/hg_cpp-0.4.9-cp312-abi3-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ae40e28418d141be95f1afea8edf85c4d46786811e722c9649971b2066408297", size = 9122709, upload-time = "2026-07-27T11:41:07.122Z" },
+    { url = "https://files.pythonhosted.org/packages/36/bb/7ec8c48057aed4c58024f9e1bdb9808007c59d237912b71d5cfaed60b3db/hg_cpp-0.4.9-cp312-abi3-win_amd64.whl", hash = "sha256:659596e1befbe45224f2af77acd99f6229cd592de53259ecff1a67513379c3f9", size = 16225388, upload-time = "2026-07-27T11:41:09.277Z" },
 ]
 
 [package.optional-dependencies]
@@ -291,7 +291,7 @@ test = [
 [package.metadata]
 requires-dist = [
     { name = "coverage", marker = "extra == 'test'" },
-    { name = "hg-cpp", extras = ["web"], specifier = ">=0.4.5" },
+    { name = "hg-cpp", extras = ["web"], specifier = ">=0.4.9" },
     { name = "holidays", specifier = ">=0.56" },
     { name = "mypy", marker = "extra == 'test'" },
     { name = "polars", specifier = ">=1.32" },


### PR DESCRIPTION
## Summary

- Replace the generated `PriceBundle` and `QuantityBundle` peer schemas with direct `TSB[Price]` and `TSB[Quantity]` signatures.
- Update order, position, and pricing-service schemas to use their dataclass definitions directly.
- Add regression coverage for direct dataclass bundle construction.
- Require and lock `hg_cpp[web]>=0.4.9`, the first released native runtime containing the dataclass-to-bundle contract.

## Why

hgraph and hg_cpp can now derive bundle schemas conservatively from dataclass properties, so hg_oap no longer needs to duplicate each domain dataclass as a peer `TimeSeriesSchema`. Keeping both forms made the domain model and its time-series shape drift-prone.

The mapping remains exact: each stored dataclass field becomes a scalar `TS[T]` child. It does not infer collection topology or perform numeric upcasting/downcasting.

## Impact and migration

The time-series field shapes are unchanged, but the duplicate public `PriceBundle` and `QuantityBundle` names are removed. Downstream code should use `TSB[Price]` and `TSB[Quantity]` directly.

## Core releases

- hgraph [PR #355](https://github.com/hhenson/hgraph/pull/355), released in [v0.5.31](https://github.com/hhenson/hgraph/releases/tag/v_0.5.31).
- hg_cpp [PR #91](https://github.com/hhenson/hg_cpp/pull/91), released in [v0.4.9](https://github.com/hhenson/hg_cpp/releases/tag/v_0.4.9).

## Validation

- `uv lock --check`.
- Built the hg_oap wheel successfully.
- Installed that wheel into a fresh Python 3.14 environment from PyPI with `hg_cpp 0.4.9` confirmed at runtime.
- Complete suite: 204 passed, 2 skipped, 2 expected failures.
- `git diff --check` and a repository-wide stale-alias reference sweep passed.